### PR TITLE
fix: add leading slashes to API endpoint paths

### DIFF
--- a/hooks/useQuery/useAnimes.ts
+++ b/hooks/useQuery/useAnimes.ts
@@ -7,7 +7,6 @@ export interface Anime {
   id: string;
   userId?: string | null;
   groupId?: string | null;
-  contentType?: string | null;
   name: string;
   channelId: string;
   thumbnail?: string;
@@ -37,7 +36,7 @@ export const getAnimes = async (params?: {
   search?: string;
 }): Promise<PaginatedAnimesResponse> => {
   const response = await apiClient.get<PaginatedAnimesResponse>(
-    "api/v2/animes",
+    "/api/v2/animes",
     params,
   );
   return response;

--- a/hooks/useQuery/useChannels.ts
+++ b/hooks/useQuery/useChannels.ts
@@ -64,7 +64,7 @@ const getChannels = async (params?: {
 	groupId?: string;
 }): Promise<ChannelsResponse> => {
 	const response = await apiClient.get<ChannelsResponse>(
-		"api/v2/channels",
+		"/api/v2/channels",
 		params,
 	);
 	return response;
@@ -72,7 +72,7 @@ const getChannels = async (params?: {
 
 const getChannel = async (id: string): Promise<Channel> => {
 	const response = await apiClient.get<ApiResponse<Channel>>(
-		`api/v2/channels/${id}`,
+		`/api/v2/channels/${id}`,
 	);
 	return response.data;
 };
@@ -87,7 +87,7 @@ const getChannelsByGroup = async (
 	},
 ): Promise<ChannelsResponse> => {
 	const response = await apiClient.get<ChannelsResponse>(
-		`api/v2/channels/group/${groupId}`,
+		`/api/v2/channels/group/${groupId}`,
 		params,
 	);
 	return response;
@@ -159,7 +159,7 @@ export function useChannelsByGroup(
 // Create a new channel
 const createChannel = async (data: CreateChannelRequest): Promise<Channel> => {
 	const response = await apiClient.post<ApiResponse<Channel>>(
-		"api/v2/channels",
+		"/api/v2/channels",
 		data,
 	);
 	return response.data;
@@ -171,7 +171,7 @@ const updateChannel = async (
 	data: UpdateChannelRequest,
 ): Promise<Channel> => {
 	const response = await apiClient.patch<ApiResponse<Channel>>(
-		`api/v2/channels/${id}`,
+		`/api/v2/channels/${id}`,
 		data,
 	);
 	return response.data;
@@ -184,7 +184,7 @@ const updateChannelsBatch = async (
 	console.log("updateChannelsBatch", data);
 	const groupId = data.channels[0].groupId;
 	const response = await apiClient.patch<ApiResponse<Channel[]>>(
-		`api/v2/channels/${groupId}/batch`,
+		`/api/v2/channels/${groupId}/batch`,
 		data,
 	);
 	return response.data;
@@ -196,7 +196,7 @@ const deleteChannel = async ({
 }: {
 	channelId: string;
 }): Promise<void> => {
-	await apiClient.delete(`api/v2/channels/${channelId}`);
+	await apiClient.delete(`/api/v2/channels/${channelId}`);
 };
 
 // React Query mutation hooks

--- a/hooks/useQuery/useDashboard.ts
+++ b/hooks/useQuery/useDashboard.ts
@@ -11,7 +11,7 @@ export type DashboardTotalResponse = {
 
 const getTotals = async (): Promise<DashboardTotalResponse> => {
 	const response = await apiClient.get<ApiResponse<DashboardTotalResponse>>(
-		"api/v2/dashboard/total",
+		"/api/v2/dashboard/total",
 	);
 	return response.data;
 };

--- a/hooks/useQuery/useGroups.ts
+++ b/hooks/useQuery/useGroups.ts
@@ -68,7 +68,7 @@ const getGroups = async (params?: {
 // Query function to fetch a single group by ID
 const getGroup = async (id: string): Promise<Group> => {
 	const response = await apiClient.get<ApiResponse<Group>>(
-		`api/v2/groups/${id}`,
+		`/api/v2/groups/${id}`,
 	);
 	return response.data;
 };
@@ -102,7 +102,7 @@ const updateGroupDisplayOrder = async (
 	groupId: string,
 	displayOrder: number,
 ): Promise<void> => {
-	await apiClient.put(`api/v2/groups/${groupId}/display-order`, {
+	await apiClient.put(`/api/v2/groups/${groupId}/display-order`, {
 		display_order: displayOrder,
 	});
 };
@@ -122,7 +122,7 @@ const updateGroup = async (
 	data: UpdateGroupRequest,
 ): Promise<Group> => {
 	const response = await apiClient.put<ApiResponse<Group>>(
-		`api/v2/groups/${id}`,
+		`/api/v2/groups/${id}`,
 		data,
 	);
 	return response.data;
@@ -130,7 +130,7 @@ const updateGroup = async (
 
 // Delete a group
 const deleteGroup = async (id: string): Promise<void> => {
-	await apiClient.delete(`api/v2/groups/${id}`);
+	await apiClient.delete(`/api/v2/groups/${id}`);
 };
 
 export function useUpdateGroupDisplayOrder() {


### PR DESCRIPTION
Ensure consistent API endpoint paths by adding leading slashes to all routes in useQuery hooks. This prevents potential routing issues when the base URL is not properly configured.