### PR TITLE
fix: update youtube channel URLs and proxy target

### DIFF
--- a/components/channels-table.tsx
+++ b/components/channels-table.tsx
@@ -149,7 +149,7 @@ export function ChannelsTable({ groupId }: ChannelsTableProps) {
 										<DropdownMenuContent align="end">
 											<DropdownMenuItem asChild>
 												<a
-													href={`${channel.contentType === 'anime' ? 'https://crunchyroll.com/series/' : 'https://youtube.com/c/'}${channel.url}`}
+													href={`${channel.contentType === 'anime' ? 'https://crunchyroll.com/series/' : 'https://youtube.com/channel/'}${channel.url}`}
 													target="_blank"
 													rel="noopener noreferrer"
 												>
@@ -210,7 +210,7 @@ export function ChannelsTable({ groupId }: ChannelsTableProps) {
 										className="flex-1"
 									>
 										<a
-											href={`${channel.contentType === 'anime' ? 'https://crunchyroll.com/series/' : 'https://youtube.com/c/'}${channel.url}`}
+											href={`${channel.contentType === 'anime' ? 'https://crunchyroll.com/series/' : 'https://youtube.com/channel/'}${channel.url}`}
 
 											target="_blank"
 											rel="noopener noreferrer"
@@ -271,7 +271,7 @@ export function ChannelsTable({ groupId }: ChannelsTableProps) {
 						<div className="flex items-center gap-2">
 							<Button variant="ghost" size="icon" className="h-7 w-7" asChild>
 								<a
-									href={`${channel.contentType === 'anime' ? 'https://crunchyroll.com/series/' : 'https://youtube.com/c/'}${channel.url}`}
+									href={`${channel.contentType === 'anime' ? 'https://crunchyroll.com/series/' : 'https://youtube.com/channel/'}${channel.url}`}
 									target="_blank"
 									rel="noopener noreferrer"
 								>

--- a/src/routes/_app/dashboard/groups/$id/add-channel/index.tsx
+++ b/src/routes/_app/dashboard/groups/$id/add-channel/index.tsx
@@ -90,7 +90,7 @@ function AddChannelPage() {
 					name: c.name,
 					channelId: c.channelId,
 					thumbnail: c.thumbnail,
-					url: `https://youtube.com/channel/${c.url}`,
+					url: c.url,
 					groupId: id,
 					contentType: c.contentType,
 					newContent: false,
@@ -147,15 +147,19 @@ function AddChannelPage() {
 	const handleSaveChannels = async () => {
 		if (selectedChannels.length === 0) return;
 
-		const channelsToUpdate = selectedChannels.map((channel) => ({
-			id: (channel.url?.trim() || "").replace("@", "") || "",
-			name: channel.name,
-			thumbnail: channel.thumbnail,
-			groupId: id,
-			contentType: channel.contentType ?? 'youtube',
-			url: channel.url || "",
-			newContent: false,
-		}));
+		const channelsToUpdate = selectedChannels.map((channel) => {
+			let url = channel.url;
+
+			return {
+				id: (url?.trim() || "").replace("@", "") || "",
+				name: channel.name,
+				thumbnail: channel.thumbnail,
+				groupId: id,
+				contentType: channel.contentType ?? 'youtube',
+				url: url || "",
+				newContent: false,
+			}
+		});
 
 		await updateChannelsBatchMutation({ channels: channelsToUpdate });
 
@@ -418,7 +422,7 @@ function AddChannelPage() {
 															{channel.contentType === "anime"
 																? `https://crunchyroll.com/series/${channel.url}`
 																: `https://youtube.com/channel/${channel.channelId?.split("/")[1]}`}
-															
+
 														</p>
 													</div>
 												</div>

--- a/src/routes/_app/dashboard/settings/billing/index.tsx
+++ b/src/routes/_app/dashboard/settings/billing/index.tsx
@@ -7,6 +7,7 @@ export const Route = createFileRoute("/_app/dashboard/settings/billing/")({
 });
 
 function RouteComponent() {
+	return null;
 	return (
 		<TabsContent value="billing" className="space-y-4">
 			<BillingSettings />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
 		cors: true,
 		proxy: {
 			"/api": {
-				target: "https://localhost",
+				target: "http://localhost:3001",
 				changeOrigin: true,
 				secure: false,
 				rewrite: (path) => path.replace(/^\/api/, ""),


### PR DESCRIPTION
- Change youtube channel URLs from '/c/' to '/channel/' for consistency
- Update proxy target to use port 3001
- Remove billing settings route component rendering
- Fix channel URL handling in add-channel page