### PR TITLE
fix: reset page on search term change and update API endpoints

### DIFF
--- a/components/all-animes-table.tsx
+++ b/components/all-animes-table.tsx
@@ -71,6 +71,7 @@ export function AllAnimesTable() {
     useEffect(() => {
         const timer = setTimeout(() => {
             setDebouncedSearchTerm(searchTerm);
+            setCurrentPage(1);
         }, 300);
 
         return () => clearTimeout(timer);

--- a/components/all-channels-table.tsx
+++ b/components/all-channels-table.tsx
@@ -72,6 +72,7 @@ export function AllChannelsTable() {
 	useEffect(() => {
 		const timer = setTimeout(() => {
 			setDebouncedSearchTerm(searchTerm);
+			setCurrentPage(1);
 		}, 300);
 
 		return () => clearTimeout(timer);

--- a/components/groups-table.tsx
+++ b/components/groups-table.tsx
@@ -76,11 +76,12 @@ export function GroupsTable() {
 	const [itemsPerPage, setItemsPerPage] = useState(25);
 	const [searchTerm, setSearchTerm] = useState("");
 	const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
-
+	
+	console.log(debouncedSearchTerm)
 	const { data: apiGroups, isLoading } = useGroups({
 		page: currentPage,
 		limit: itemsPerPage,
-		search: debouncedSearchTerm,
+		search: debouncedSearchTerm || undefined,
 	});
 
 	const updateDisplayOrder = useUpdateGroupDisplayOrder();
@@ -110,8 +111,10 @@ export function GroupsTable() {
 	const [draggedGroup, setDraggedGroup] = useState<TableGroup | null>(null);
 	const [dragOverGroup, setDragOverGroup] = useState<string | null>(null);
 	useEffect(() => {
+		console.log(searchTerm)
 		const timer = setTimeout(() => {
 			setDebouncedSearchTerm(searchTerm);
+			setCurrentPage(1);
 		}, 300);
 
 		return () => clearTimeout(timer);
@@ -125,7 +128,6 @@ export function GroupsTable() {
 	// biome-ignore lint/correctness/useExhaustiveDependencies: <cant apply the rule as the transformApiGroups changes on every render>
 	useEffect(() => {
 		if (apiGroups?.data) {
-			console.log("apiGroups?.data", apiGroups?.data);
 			const newGroups = transformApiGroups(apiGroups.data);
 			const savedOrder = localStorage.getItem("groupsOrder");
 

--- a/hooks/useQuery/useAnimes.ts
+++ b/hooks/useQuery/useAnimes.ts
@@ -36,7 +36,7 @@ export const getAnimes = async (params?: {
   search?: string;
 }): Promise<PaginatedAnimesResponse> => {
   const response = await apiClient.get<PaginatedAnimesResponse>(
-    "/api/v2/animes",
+    "/api/v3/animes",
     params,
   );
   return response;

--- a/hooks/useQuery/useChannels.ts
+++ b/hooks/useQuery/useChannels.ts
@@ -63,6 +63,7 @@ const getChannels = async (params?: {
 	search?: string;
 	groupId?: string;
 }): Promise<ChannelsResponse> => {
+	console.log("params", params);
 	const response = await apiClient.get<ChannelsResponse>(
 		"/api/v2/channels",
 		params,

--- a/hooks/useQuery/useGroups.ts
+++ b/hooks/useQuery/useGroups.ts
@@ -61,6 +61,7 @@ const getGroups = async (params?: {
 	limit?: number;
 	search?: string;
 }): Promise<GroupsResponse> => {
+	console.log("params", params);
 	const response = await apiClient.get<GroupsResponse>("api/v2/groups", params);
 	return response;
 };
@@ -80,7 +81,7 @@ export function useGroups(params?: {
 	search?: string;
 }) {
 	return useQuery({
-		queryKey: ["groups"],
+		queryKey: queryKeys.groups(params),
 		queryFn: () => getGroups(params),
 		staleTime: 5 * 60 * 1000, // 5 minutes
 		gcTime: 10 * 60 * 1000, // 10 minutes


### PR DESCRIPTION
- Reset current page to 1 when search term changes in tables
- Update anime API endpoint from v2 to v3
- Add debug logging for API params
- Fix query key generation for groups query