### PR TITLE
fix: remove console log and sync category removal with localStorage

### DIFF
--- a/components/groups-table.tsx
+++ b/components/groups-table.tsx
@@ -99,7 +99,6 @@ export function GroupsTable() {
 	const [searchTerm, setSearchTerm] = useState("");
 	const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
 
-	console.log(debouncedSearchTerm)
 	const { data: apiGroups, isLoading } = useGroups({
 		page: currentPage,
 		limit: itemsPerPage,

--- a/components/settings/group-settings.tsx
+++ b/components/settings/group-settings.tsx
@@ -89,6 +89,18 @@ export function GroupSettings() {
 
 	const removeCategory = (category: string) => {
 		setCategories(categories.filter((c) => c !== category));
+		const savedSettings = localStorage.getItem("groupSettings");
+		if (savedSettings) {
+			try {
+				const settings = JSON.parse(savedSettings);
+				if (settings.categories && Array.isArray(settings.categories)) {
+					settings.categories = settings.categories.filter((c) => c !== category);
+					localStorage.setItem("groupSettings", JSON.stringify(settings));
+				}
+			} catch (error) {
+				console.error("Error parsing settings:", error);
+			}
+		}
 	};
 
 	const saveSettings = async () => {


### PR DESCRIPTION
Remove debug console.log statement from groups-table component. Update group-settings component to persist category removal to localStorage, ensuring settings are saved when categories are deleted.