### PR TITLE
feat(groups): add breadcrumbs and child groups to group detail page

### DIFF
--- a/components/group-details.tsx
+++ b/components/group-details.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { Pencil, Share2 } from "lucide-react";
+import { Pencil, Plus, Share2 } from "lucide-react";
 import { IconViewer } from "@/components/icon-picker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -36,15 +36,6 @@ export function GroupDetails({ id }: GroupDetailsProps) {
 						</div>
 						<div>
 							<div className="flex items-center gap-2">
-								{group.parentId && (
-									<Link
-										to={`/dashboard/groups/$id`}
-										params={{ id: group.parentId ?? "" }}
-										className="text-sm text-muted-foreground hover:underline"
-									>
-										{group.parentId} /
-									</Link>
-								)}
 								<CardTitle>{group.name}</CardTitle>
 							</div>
 							<CardDescription>{group.description}</CardDescription>
@@ -67,6 +58,12 @@ export function GroupDetails({ id }: GroupDetailsProps) {
 								Share
 							</Link>
 						</Button>
+						<Button variant="outline" type="button" asChild>
+							<Link to={"/dashboard/groups/$id/add-channel"} params={{ id: group.id }}>
+								<Plus className="mr-2 h-4 w-4" />
+								Add Channel
+							</Link>
+						</Button>	
 					</div>
 				</div>
 			</CardHeader>

--- a/src/routes/_app/dashboard/groups/$id/index.tsx
+++ b/src/routes/_app/dashboard/groups/$id/index.tsx
@@ -1,17 +1,30 @@
 "use client";
 
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Plus, Users } from "lucide-react";
-import { useEffect, useRef } from "react";
+import { ChevronRight, Home, Play, Plus, Users } from "lucide-react";
+import { useEffect, useMemo, useRef } from "react";
 import { toast } from "sonner";
 import { ChannelsTable } from "@/components/channels-table";
 import { DashboardHeader } from "@/components/dashboard-header";
 import { GroupDetails } from "@/components/group-details";
 import { GroupVideosList } from "@/components/group-videos-list";
+import { IconViewer } from "@/components/icon-picker";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import {
+	Breadcrumb,
+	BreadcrumbItem,
+	BreadcrumbLink,
+	BreadcrumbList,
+	BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { useGroup, useSyncGroupVideos } from "@/hooks/useQuery/useGroups";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+	useGroup,
+	useGroups,
+	useSyncGroupVideos,
+} from "@/hooks/useQuery/useGroups";
 
 export const Route = createFileRoute("/_app/dashboard/groups/$id/")({
 	component: GroupDetailPage,
@@ -20,8 +33,49 @@ export const Route = createFileRoute("/_app/dashboard/groups/$id/")({
 function GroupDetailPage() {
 	const { id } = Route.useParams();
 	const { data: group } = useGroup(id);
+	const { data: groupsData } = useGroups({ limit: 100 });
 	const syncVideos = useSyncGroupVideos();
 	const syncedIdRef = useRef<string | null>(null);
+
+	const breadcrumbs = useMemo(() => {
+		if (!group || !groupsData?.data) return [];
+
+		const crumbs: (typeof group)[] = [];
+		let current: typeof group | undefined = group;
+
+		while (current) {
+			crumbs.unshift(current);
+			if (current.parentId) {
+				current = groupsData.data.find((g) => g.id === current!.parentId);
+			} else {
+				current = undefined;
+			}
+		}
+
+		return crumbs;
+	}, [group, groupsData]);
+
+	type GroupType = NonNullable<typeof group>;
+
+	const childGroups = useMemo(() => {
+		if (!groupsData?.data || !group) return [];
+
+		const getAllDescendants = (parentId: string): GroupType[] => {
+			const directChildren = groupsData.data.filter(
+				(g) => g.parentId === parentId,
+			);
+			const descendants: GroupType[] = [];
+			for (const child of directChildren) {
+				if (child) {
+					descendants.push(child);
+					descendants.push(...getAllDescendants(child.id));
+				}
+			}
+			return descendants;
+		};
+
+		return getAllDescendants(id);
+	}, [groupsData, id, group]);
 
 	useEffect(() => {
 		if (syncedIdRef.current !== id) {
@@ -54,34 +108,80 @@ function GroupDetailPage() {
 
 	return (
 		<div className="space-y-6">
-			<div className="flex items-center justify-between">
-				<DashboardHeader
-					title={group.name}
-					description="Manage channels in this group"
-				/>
-				<Button variant="outline" type="button" asChild>
-					<Link to={"/dashboard/groups/$id/add-channel"} params={{ id: id }}>
-						<Plus className="mr-2 h-4 w-4" />
-						Add Channel
-					</Link>
-				</Button>
-			</div>
+			{breadcrumbs.length > 0 && (
+				<Breadcrumb>
+					<BreadcrumbList>
+						<BreadcrumbItem>
+							<BreadcrumbLink href="/dashboard/groups">
+								<Home className="h-4 w-4" />
+							</BreadcrumbLink>
+						</BreadcrumbItem>
+						{breadcrumbs.map((crumb, index) => (
+							<>
+								<BreadcrumbSeparator key={`sep-${crumb.id}`}>
+									<ChevronRight className="h-4 w-4" />
+								</BreadcrumbSeparator>
+								<BreadcrumbItem key={crumb.id}>
+									{index === breadcrumbs.length - 1 ? (
+										<span className="font-medium">{crumb.name}</span>
+									) : (
+										<BreadcrumbLink href={`/dashboard/groups/${crumb.id}`}>
+											{crumb.name}
+										</BreadcrumbLink>
+									)}
+								</BreadcrumbItem>
+							</>
+						))}
+					</BreadcrumbList>
+				</Breadcrumb>
+			)}
+			{childGroups.length > 0 && (
+				<div className="grid gap-2 grid-cols-2 sm:grid-cols-3 lg:grid-cols-4">
+					{childGroups.map((child) => (
+						<Link
+							key={child.id}
+							to="/dashboard/groups/$id"
+							params={{ id: child.id }}
+							className="flex items-center gap-2 p-3 border rounded-lg hover:bg-accent transition-colors"
+						>
+							<Avatar className="h-5 w-5">
+								<IconViewer icon={child.icon || "folder"} />
+								<AvatarFallback>
+									<Users className="h-3 w-3" />
+								</AvatarFallback>
+							</Avatar>
+							<div className="flex-1 min-w-0">
+								<p className="font-medium truncate">{child.name}</p>
+								<p className="text-xs text-muted-foreground">
+									{child.channelCount} channels
+								</p>
+							</div>
+						</Link>
+					))}
+				</div>
+			)}
 			<GroupDetails id={id} />
-			<GroupVideosList groupId={id} />
-			<Card>
-				<CardHeader className="flex flex-row items-center justify-between pb-4">
-					<CardTitle className="text-lg flex items-center gap-2">
-						<Users className="h-5 w-5 text-red-500" />
-						Channels in this group
-						<Badge variant="secondary" className="ml-2">
+			<Tabs defaultValue="channels" className="space-y-4">
+				<TabsList>
+					<TabsTrigger value="channels" className="flex items-center gap-2">
+						<Users className="h-4 w-4" />
+						Channels
+						<Badge variant="secondary" className="ml-1">
 							{group.channels?.length || 0}
 						</Badge>
-					</CardTitle>
-				</CardHeader>
-				<CardContent className="pt-0">
+					</TabsTrigger>
+					<TabsTrigger value="videos" className="flex items-center gap-2">
+						<Play className="h-4 w-4" />
+						Videos
+					</TabsTrigger>
+				</TabsList>
+				<TabsContent value="channels">
 					<ChannelsTable groupId={id} />
-				</CardContent>
-			</Card>
+				</TabsContent>
+				<TabsContent value="videos">
+					<GroupVideosList groupId={id} />
+				</TabsContent>
+			</Tabs>
 		</div>
 	);
 }

--- a/src/routes/_app/dashboard/route.tsx
+++ b/src/routes/_app/dashboard/route.tsx
@@ -87,7 +87,6 @@ function DashboardLayout() {
 					<header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
 						<SidebarTrigger className="-ml-1" />
 						<Separator orientation="vertical" className="mr-2 h-4" />
-						<DashboardBreadcrumb />
 					</header>
 					<main className="flex-1 overflow-auto p-6">
 						<Outlet />


### PR DESCRIPTION
- Replace dashboard breadcrumb with hierarchical breadcrumbs showing parent groups
- Display child groups in a grid view with icons and channel counts
- Reorganize content into tabs for channels and videos
- Remove redundant parent link from group details component
- Add "Add Channel" button to group details header