### PR TITLE
chore: remove @umami/node dependency and switch to script tag

### DIFF
--- a/hooks/useQuery/useUser.ts
+++ b/hooks/useQuery/useUser.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { type ApiResponse, apiClient } from "@/hooks/api/api-client";
 import { queryKeys } from "@/hooks/utils/queryKeys";
-import { umamiClient, op } from "@/routes/__root";
+import { op } from "@/routes/__root";
 
 // Types for the User
 export interface User {
@@ -37,7 +37,9 @@ const getUser = async (): Promise<User> => {
 		},
 	};
 	op.identify(identifyOptions);
-	umamiClient.identify(identifyOptions);
+	if ((window as any).umami) {
+	  	(window as any).umami.identify(identifyOptions);
+    }
 	return response.data;
 };
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
 		"@tanstack/react-start": "1.145.0",
 		"@tanstack/react-table": "8.21.3",
 		"@tanstack/zod-adapter": "^1.144.0",
-		"@umami/node": "^0.4.0",
 		"@vitejs/plugin-react": "5.1.2",
 		"autoprefixer": "^10.4.21",
 		"class-variance-authority": "^0.7.1",

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -19,14 +19,10 @@ import { Toaster } from "@/components/ui/sonner";
 import { queryClient } from "@/hooks/utils/queryClient";
 import appCss from "@/styles/app.css?url";
 import posthog from "posthog-js";
-import HyperDX from '@hyperdx/browser';
 import { AnalyticsListener } from "@/hooks/analytics-listener";
 import { OpenPanel } from '@openpanel/web';
-import {Umami} from '@umami/node';
 
 const PUBLIC_POST_HOG_ID = import.meta.env.VITE_POST_HOG_ID;
-const PUBLIC_HYPER_DX_ID = import.meta.env.VITE_HYPER_DX_ID;
-const PUBLIC_HYPER_DX_URL = import.meta.env.VITE_HYPER_DX_URL;
 const NODE_ENV = import.meta.env.MODE;
 
 if (
@@ -72,10 +68,6 @@ export const op = new OpenPanel({
 	apiUrl: 'https://opapi.groupify.dev',
 });
 
-export const umamiClient = new Umami({
-	websiteId: '12a8d73a-1f10-4dcd-ae0b-7e2b16de3338',
-	hostUrl: 'https://umami.groupify.dev/script.js'
-});
 
 function RootComponent() {
 	return (
@@ -134,6 +126,7 @@ function RootDocument({ children }: Readonly<{ children: ReactNode }>) {
 						gtag('config', 'G-D7BS3V6VJF');
 					`}
 				</script>
+				<script defer src="https://umami.groupify.dev/script.js" data-website-id="12a8d73a-1f10-4dcd-ae0b-7e2b16de3338"></script>
 				<Scripts />
 			</body>
 		</html>


### PR DESCRIPTION
The @umami/node package is removed from dependencies as the client-side analytics integration is now handled via a direct script tag in the root document. This simplifies the setup and removes an unnecessary npm dependency. The umami client initialization in useUser hook is updated to use the global window.umami object.