### PR TITLE
fix(apple-app-site-association): update format for universal links an…

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,10 +1,17 @@
 {
   "applinks": {
+    "apps": [],
     "details": [
       {
-        "appIDs": ["UM6SZWPURL.com.groupifyapp"],
-        "components": [{ "/": "/*" }]
+        "appID": "UM6SZWPURL.com.groupifyapp",
+        "paths": ["/oauth/*"]
       }
     ]
+  },
+  "activitycontinuation": {
+    "apps": ["UM6SZWPURL.com.groupifyapp"]
+  },
+  "webcredentials": {
+    "apps": ["UM6SZWPURL.com.groupifyapp"]
   }
 }


### PR DESCRIPTION
…d capabilities

The previous JSON format was outdated and caused issues with iOS universal linking and other capabilities. Update to the current required structure, adding support for activity continuation and web credentials by specifying the appID and paths explicitly.