### PR TITLE
chore: update apple-app-site-association to new JSON structure

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,17 +1,27 @@
 {
   "applinks": {
-    "apps": [],
     "details": [
       {
-        "appID": "UM6SZWPURL.com.groupifyapp",
-        "paths": ["/oauth/*"]
+        "appIDs": [
+          "UM6SZWPURL.com.groupifyapp"
+        ],
+        "components": [
+          {
+            "/": "*",
+            "comment": "Matches all routes"
+          }
+        ]
       }
     ]
   },
   "activitycontinuation": {
-    "apps": ["UM6SZWPURL.com.groupifyapp"]
+    "apps": [
+      "UM6SZWPURL.com.groupifyapp"
+    ]
   },
   "webcredentials": {
-    "apps": ["UM6SZWPURL.com.groupifyapp"]
+    "apps": [
+      "UM6SZWPURL.com.groupifyapp"
+    ]
   }
 }


### PR DESCRIPTION
Update the Apple App Site Association file to match the current required JSON format. The 'details' array now uses 'appIDs' and 'components' instead of 'appID' and 'paths'. This ensures compatibility with Apple's Universal Link and associated domain services.