### PR TITLE
docs(dashboard-stats): clarify card title for total channels metric

### DIFF
--- a/components/dashboard-stats.tsx
+++ b/components/dashboard-stats.tsx
@@ -41,7 +41,7 @@ export function DashboardStats() {
 			</Card>
 			<Card>
 				<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-					<CardTitle className="text-sm font-medium">Total Channels</CardTitle>
+					<CardTitle className="text-sm font-medium">Total Channels inside Groups</CardTitle>
 					<Youtube className="h-4 w-4 text-muted-foreground" />
 				</CardHeader>
 				<CardContent>


### PR DESCRIPTION
Update the dashboard card title from "Total Channels" to "Total Channels inside Groups" to provide more accurate context about what the metric represents.