### PR TITLE
feat(landing-page): add FoundrList badge and increase Acid Tools badg…

### DIFF
--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -891,8 +891,11 @@ export function LandingPage() {
 								<img
 									src="https://acidtools.com/assets/images/badge-dark.png"
 									alt="Acid Tools"
-									className="h-8"
+									className="h-12"
 								/>
+							</a>
+							<a href="https://www.foundrlist.com/product/groupify-2?utm_source=badge&amp;utm_medium=embed" target="_blank" rel="noopener">
+								<img src="https://www.foundrlist.com/api/badge/groupify-2" alt="Featured on FoundrList" width="150" height="48" />
 							</a>
 						</div>
 					</div>

--- a/src/routes/_app/dashboard/index.tsx
+++ b/src/routes/_app/dashboard/index.tsx
@@ -22,7 +22,6 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { UpgradePlanModal } from "@/components/upgrade-plan-modal";
-import { YouTubeConnectModal } from "@/components/youtube-connect-modal";
 import { useUser } from "@/hooks/useQuery/useUser";
 import { useDashboardTotal } from "@/hooks/useQuery/useDashboard";
 
@@ -185,10 +184,6 @@ function DashboardPage() {
 					type={upgradeModalType}
 				/>
 			)}
-			<YouTubeConnectModal
-				open={showYouTubeModal}
-				onOpenChange={setShowYouTubeModal}
-			/>
 
 			{user && (
 				<WelcomeSection


### PR DESCRIPTION
…e size

Increase the height of the existing Acid Tools badge from `h-8` to `h-12` and add a new badge linking to the product page on FoundrList. Remove the unused YouTubeConnectModal component import and instance from the dashboard page to clean up the code.