### PR TITLE
chore: add AdSense app-ads.txt file for ad verification

### DIFF
--- a/public/app-ads.txt
+++ b/public/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-4077364511521347, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
Include the required app-ads.txt file in the public directory to allow Google AdSense to verify the app and serve ads. This file contains the publisher ID and required directives.